### PR TITLE
Add flag to remove s3 path from stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ struct Opt {
     prefix: String,
 
     /// Number of concurrent tasks
-    #[structopt(short, long, default_value = "8")]
+    #[structopt(short = "j", long, default_value = "8")]
     concurrent_tasks: usize,
 
     /// Case sensitive search
@@ -56,9 +56,9 @@ struct Opt {
     #[structopt(short = "n", long)]
     line_number: bool,
 
-    /// Remove the leading `s3://bucket/key` prefix from stdout lines
-    #[structopt(long)]
-    strip_s3_path: bool,
+    /// Only print matched content (omit s3://bucket/key prefix)
+    #[structopt(short = "c", long)]
+    content_only: bool,
 }
 
 use anyhow::Result;
@@ -171,7 +171,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let progress = progress.clone();
         let byte_progress = byte_progress.clone();
         let line_numbers = opt.line_number;
-        let strip_s3_path = opt.strip_s3_path;
+        let content_only = opt.content_only;
 
         async move {
             match obj {
@@ -201,7 +201,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     {
                         Ok(matches) => {
                             for (line_num, line) in matches {
-                                let msg = if strip_s3_path {
+                                let msg = if content_only {
                                     if line_numbers {
                                         format!("{}:{}", line_num, highlight_match(&line, &pattern))
                                     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ struct Opt {
     /// Line numbers
     #[structopt(short = "n", long)]
     line_number: bool,
+
+    /// Remove the leading `s3://bucket/key` prefix from stdout lines
+    #[structopt(long)]
+    strip_s3_path: bool,
 }
 
 use anyhow::Result;
@@ -167,6 +171,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let progress = progress.clone();
         let byte_progress = byte_progress.clone();
         let line_numbers = opt.line_number;
+        let strip_s3_path = opt.strip_s3_path;
 
         async move {
             match obj {
@@ -196,7 +201,13 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     {
                         Ok(matches) => {
                             for (line_num, line) in matches {
-                                let msg = if line_numbers {
+                                let msg = if strip_s3_path {
+                                    if line_numbers {
+                                        format!("{}:{}", line_num, highlight_match(&line, &pattern))
+                                    } else {
+                                        format!("{}", highlight_match(&line, &pattern))
+                                    }
+                                } else if line_numbers {
                                     format!(
                                         "s3://{}/{}:{}:{}",
                                         bucket,


### PR DESCRIPTION
Add `--strip-s3-path` flag to `s3grep` to remove the S3 path prefix from stdout lines, improving readability for users who don't need the full path.

---
<a href="https://cursor.com/background-agent?bcId=bc-61f74bfb-5146-4ba2-9592-80eacdd6ccbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61f74bfb-5146-4ba2-9592-80eacdd6ccbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

